### PR TITLE
Update ruleset.cpp

### DIFF
--- a/src/ruleset.cpp
+++ b/src/ruleset.cpp
@@ -1,8 +1,13 @@
+Killbots::Ruleset::~Ruleset()
+{
+}
+qCDebug(KILLBOTS_LOG) << "Failed to load " << fileName;
+QString untranslatedName = KConfigGroup(config(), QStringLiteral("KillbotsRuleset")).readEntryUntranslated("Name");
+m_scoreGroupKey = untranslatedName.simplified().remove(QLatin1Char(' ')).toLatin1();
 /*
     This file is part of Killbots.
 
-    SPDX-FileCopyrightText: 2007-2009 Parker Coates <coates@kde.org>
-
+    SPDX-FileCopyrightText: 2007-2009 Parker Coates
     SPDX-License-Identifier: GPL-2.0-or-later
 */
 
@@ -12,51 +17,71 @@
 #include "killbots_debug.h"
 
 #include <QFileInfo>
+#include <memory>  // for std::unique_ptr
 
-const Killbots::Ruleset *Killbots::Ruleset::load(const QString &fileName)
+namespace Killbots {
+
+std::unique_ptr<Ruleset> Ruleset::load(const QString &fileName)
 {
-    const Ruleset *result = nullptr;
-    if (!fileName.isEmpty()) {
-        QString filePath = QStandardPaths::locate(QStandardPaths::GenericDataLocation, QLatin1String("killbots/rulesets/") + fileName);
-        if (!filePath.isEmpty()) {
-            // Our only check for validity is that we can open the file as a config
-            // file and that it contains a group named "KillbotsRuleset".
-            KConfig configFile(filePath, KConfig::SimpleConfig);
-            if (configFile.hasGroup(QStringLiteral("KillbotsRuleset"))) {
-                result = new Ruleset(filePath);
-            }
-        }
-    }
-    if (!result) {
-        qCDebug(KILLBOTS_LOG) << "Failed to load " << fileName;
+    if (fileName.isEmpty()) {
+        qCDebug(KILLBOTS_LOG) << "Failed to load: empty file name.";
+        return nullptr;
     }
 
-    return result;
+    // Locate the ruleset path
+    const QString filePath = QStandardPaths::locate(
+        QStandardPaths::GenericDataLocation,
+        QLatin1String("killbots/rulesets/") + fileName
+    );
+
+    if (filePath.isEmpty()) {
+        qCDebug(KILLBOTS_LOG) << "Failed to locate" << fileName;
+        return nullptr;
+    }
+
+    // Check config validity
+    KConfig configFile(filePath, KConfig::SimpleConfig);
+    if (!configFile.hasGroup(QStringLiteral("KillbotsRuleset"))) {
+        qCDebug(KILLBOTS_LOG) << "Invalid ruleset (no [KillbotsRuleset] group):" << fileName;
+        return nullptr;
+    }
+
+    // Create and return a new Ruleset instance
+    return std::unique_ptr<Ruleset>(new Ruleset(filePath));
 }
 
-Killbots::Ruleset::Ruleset(const QString &filePath)
+Ruleset::Ruleset(const QString &filePath)
     : RulesetBase(KSharedConfig::openConfig(filePath))
+    , m_filePath(filePath)
 {
-    m_filePath = filePath;
-    QString untranslatedName = KConfigGroup(config(), QStringLiteral("KillbotsRuleset")).readEntryUntranslated("Name");
-    m_scoreGroupKey = untranslatedName.simplified().remove(QLatin1Char(' ')).toLatin1();
+    // Build the score group key from the "Name" entry
+    const QString untranslatedName = KConfigGroup(
+        config(), QStringLiteral("KillbotsRuleset")
+    ).readEntryUntranslated("Name");
+
+    // Simplify and remove spaces, then convert to Latin-1
+    m_scoreGroupKey = untranslatedName
+        .simplified()
+        .remove(QLatin1Char(' '))
+        .toLatin1();
 }
 
-Killbots::Ruleset::~Ruleset()
-{
-}
+// No need for an empty destructor if there's nothing special to do
 
-QString Killbots::Ruleset::filePath() const
+QString Ruleset::filePath() const
 {
     return m_filePath;
 }
 
-QString Killbots::Ruleset::fileName() const
+QString Ruleset::fileName() const
 {
     return QFileInfo(m_filePath).fileName();
 }
 
-QByteArray Killbots::Ruleset::scoreGroupKey() const
+QByteArray Ruleset::scoreGroupKey() const
 {
     return m_scoreGroupKey;
 }
+
+} // namespace Killbots
+


### PR DESCRIPTION
1. Verify Understanding This C++ file defines a Killbots::Ruleset class used within the KDE game Killbots. Its key functions include:

Loading a ruleset file by searching in standard data locations (QStandardPaths::locate). Validating the file by checking if there is a KillbotsRuleset config group in a KConfig file. Storing metadata about the ruleset, such as the file path, file name, and a simplified, space-free scoreGroupKey derived from the “Name” entry in the config. The code returns a raw pointer to a newly allocated Ruleset or nullptr if the file is invalid/missing, logging a debug message on failure.

2. Outline Approach Review the Core Features:

Loading and verifying the config file.
Building a scoreGroupKey from the untranslated name. Storing and retrieving file paths and names.
Analyze Potential Improvements:

Memory management and error handling (using modern C++ pointers or returning a smart pointer/optional). Handling edge cases (e.g., empty or malformed config entries). Improving the readability and maintainability (e.g., removing unnecessary/destructor, clarifying code comments). Propose an Updated Version:

Use std::unique_ptr or std::optional for safer memory handling. Discuss minor code clarifications.
Keep the overall behavior intact for integration with existing Killbots code.
3. In-Depth Critique & Best Practice Suggestions 3.1 Memory Management
Currently, load(const QString &fileName) returns a raw pointer (const Ruleset *). If the caller forgets to delete it, there’s a risk of a memory leak. You have a few modern alternatives:

std::unique_ptr<Ruleset>:

Return a std::unique_ptr<Ruleset> instead of a raw pointer. Ensures automatic cleanup when the caller no longer needs the ruleset. The caller can still release ownership if needed.
std::shared_ptr<Ruleset>:

If multiple owners in the codebase might share the same ruleset. Overkill if there is clearly only one owner.
std::optional<Ruleset> (stack-based approach):

If the Ruleset is trivially copyable or movable, you could avoid dynamic allocation. Return std::optional<Ruleset> which is std::nullopt on failure. Any of these approaches reduce the chance of forgetting to delete the object.

3.2 Constructor / Destructors
The destructor is empty:

cpp
Copy code
Killbots::Ruleset::~Ruleset()
{
}
An empty destructor can be removed if there’s no special cleanup needed. The compiler will generate a default destructor for you. This is purely a cosmetic/trivial improvement.

3.3 File Validation & Error Handling
The code checks if the file can be opened and if it has a KillbotsRuleset group. If not, logs a debug message: cpp
Copy code
qCDebug(KILLBOTS_LOG) << "Failed to load " << fileName; You might consider more explicit error messages or exceptions if this is truly “fatal.” But for a game, a simple debug message is likely sufficient. 3.4 Score Group Key Generation
cpp
Copy code
QString untranslatedName = KConfigGroup(config(), QStringLiteral("KillbotsRuleset")).readEntryUntranslated("Name"); m_scoreGroupKey = untranslatedName.simplified().remove(QLatin1Char(' ')).toLatin1(); simplified() handles trimming and reducing multiple spaces to one, then remove(QLatin1Char(' ')) strips them out. That’s fine if you only want the letters for the score group key, but note that simplified() already collapses multiple whitespace runs. If you want to handle non-standard spacing or want the name in a “URL-friendly” format, you might consider a more thorough sanitize. But for local usage, this is likely sufficient. 3.5 Return Type & Usage
The function returns nullptr on failure. In usage, be sure any caller checks for nullptr before proceeding. If you convert to a smart pointer, the usage changes slightly (if (!rulesetPtr) { /* handle error */ }). 3.6 KConfig & KSharedConfig
RulesetBase(KSharedConfig::openConfig(filePath)) presumably sets up all the config reading. That’s standard in KDE code. If further validations are needed (like verifying certain keys exist in the config group), you might do it in the constructor or provide an isValid() method.
4. Example Refined Code (Using std::unique_ptr) Below is an example that returns std::unique_ptr<Ruleset> for safer memory management. The rest of the logic remains nearly identical. Also, note we’ve omitted the empty destructor:

cpp
Copy code
/*
    This file is part of Killbots.

    SPDX-FileCopyrightText: 2007-2009 Parker Coates
    SPDX-License-Identifier: GPL-2.0-or-later
*/

#include "ruleset.h"

#include <KConfigGroup>
#include "killbots_debug.h"

#include <QFileInfo>
#include <memory>  // for std::unique_ptr

namespace Killbots {

std::unique_ptr<Ruleset> Ruleset::load(const QString &fileName) {
    if (fileName.isEmpty()) {
        qCDebug(KILLBOTS_LOG) << "Failed to load: empty file name.";
        return nullptr;
    }

    // Locate the ruleset path
    const QString filePath = QStandardPaths::locate(
        QStandardPaths::GenericDataLocation,
        QLatin1String("killbots/rulesets/") + fileName
    );

    if (filePath.isEmpty()) {
        qCDebug(KILLBOTS_LOG) << "Failed to locate" << fileName;
        return nullptr;
    }

    // Check config validity
    KConfig configFile(filePath, KConfig::SimpleConfig);
    if (!configFile.hasGroup(QStringLiteral("KillbotsRuleset"))) {
        qCDebug(KILLBOTS_LOG) << "Invalid ruleset (no [KillbotsRuleset] group):" << fileName;
        return nullptr;
    }

    // Create and return a new Ruleset instance
    return std::unique_ptr<Ruleset>(new Ruleset(filePath));
}

Ruleset::Ruleset(const QString &filePath)
    : RulesetBase(KSharedConfig::openConfig(filePath))
    , m_filePath(filePath)
{
    // Build the score group key from the "Name" entry
    const QString untranslatedName = KConfigGroup(
        config(), QStringLiteral("KillbotsRuleset")
    ).readEntryUntranslated("Name");

    // Simplify and remove spaces, then convert to Latin-1
    m_scoreGroupKey = untranslatedName
        .simplified()
        .remove(QLatin1Char(' '))
        .toLatin1();
}

// No need for an empty destructor if there's nothing special to do

QString Ruleset::filePath() const
{
    return m_filePath;
}

QString Ruleset::fileName() const
{
    return QFileInfo(m_filePath).fileName();
}

QByteArray Ruleset::scoreGroupKey() const
{
    return m_scoreGroupKey;
}

} // namespace Killbots
Explanation of Changes
Return std::unique_ptr<Ruleset>: Ensures the object is memory-managed. Check for Edge Cases: We print debug logs if the file is empty or can’t be located, or if it’s missing the [KillbotsRuleset] group. Removed Empty Destructor: The compiler provides a default destructor. Minor Style Tweaks: Using inlined local variables for clarity, avoiding multiple nested if (!...) return; statements.
5. Further Improvements Additional Config Validation
If the config must have specific keys besides [KillbotsRuleset]/Name, you could read and validate them in the constructor or provide an isValid() method. Localization
readEntryUntranslated("Name") is intentionally not localized, presumably because you want a stable key. This is fine. If you ever needed a user-facing name, you’d also read a translated version. Testing
Ensure you have a small unit test verifying that a known valid ruleset loads successfully, and that an invalid file logs a warning and returns nullptr. Conclusion
This Ruleset code is fairly straightforward and aligns well with KDE/Qt patterns. The main suggestion is adopting modern C++ memory-management patterns (e.g., returning a smart pointer from load) to avoid manual delete calls. Additionally, removing the empty destructor and verifying that _scoreGroupKey suits your needs will further tidy up the code.